### PR TITLE
Fix cast_type lookup for Rails 8.1 compatibility

### DIFF
--- a/lib/sorbet-rails/model_column_utils.rb
+++ b/lib/sorbet-rails/model_column_utils.rb
@@ -29,9 +29,16 @@ module SorbetRails::ModelColumnUtils
 
   sig { params(column_def: T.untyped).returns(ColumnType) }
   def type_for_column_def(column_def)
-    cast_type = ActiveRecord::Base.connection.respond_to?(:lookup_cast_type_from_column) ?
-      ActiveRecord::Base.connection.lookup_cast_type_from_column(column_def) :
-      column_def.cast_type
+    connection = ActiveRecord::Base.connection
+    cast_type =
+      if connection.respond_to?(:lookup_cast_type_from_column)
+        connection.lookup_cast_type_from_column(column_def)
+      else
+        # Rails 8.1 removed `lookup_cast_type_from_column` and made
+        # `Column#cast_type` protected. `lookup_cast_type(sql_type)` is the
+        # public equivalent (it's what the removed method called internally).
+        connection.lookup_cast_type(column_def.sql_type)
+      end
 
     array_type = false
     if column_def.try(:array?)


### PR DESCRIPTION
Rails 8.1 broke `rake rails_rbi:models` for every model: `protected method 'cast_type' called for ... PostgreSQL::Column`.

Two converging Rails 8.1 changes hit `ModelColumnUtils#type_for_column_def`: `lookup_cast_type_from_column` was removed (so the `respond_to?` guard falls through), and `Column#cast_type` became `protected` (so the fallback raises).

Fix: fall back to the public `connection.lookup_cast_type(column_def.sql_type)` — what the removed method called internally. Backward-compatible with Rails <= 8.0.

Validated on Rails 8.1.3: `rake rails_rbi:models` → 0 cast_type errors across 301 models; `srb tc` clean.
